### PR TITLE
Add advanced GXMA fusion strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This approach trains a linear classifier on top of frozen image embeddings extra
 **For GXMA Fusion Detector Training:**
 
 The GXMA Fusion Detector integrates frequency features with CLIP semantics.
-1.  **Configure**: Edit `configs/gxma_fusion_config.yaml` with dataset paths and parameters.
+1.  **Configure**: Edit `configs/gxma_fusion_config.yaml` with dataset paths and parameters. Variants `gxma_fusion_parallel.yaml` and `gxma_fusion_gated.yaml` set alternative fusion strategies.
 2.  **Run training script**:
     ```bash
     python src/training/train_gxma.py --config configs/gxma_fusion_config.yaml

--- a/configs/README.md
+++ b/configs/README.md
@@ -74,5 +74,7 @@ vlm:
 - `vlm_fine_tune.yaml`: Example configuration for VLM fine-tuning.
 - `vlm_zero_shot.yaml`: An older or alternative configuration for zero-shot VLM evaluation, possibly for a single model run.
 - `gxma_fusion_config.yaml`: Configuration for training the GXMA Fusion Detector proof of concept.
+- `gxma_fusion_parallel.yaml`: Uses the parallel attention fusion strategy (Strategy B).
+- `gxma_fusion_gated.yaml`: Uses the hierarchical gating fusion strategy (Strategy C).
 
 These files should be documented similarly as their functionalities are developed or integrated into experimental workflows. 

--- a/configs/gxma_fusion_gated.yaml
+++ b/configs/gxma_fusion_gated.yaml
@@ -2,7 +2,7 @@
 
 general:
   output_dir: "results/gxma_runs"  # Base directory for all outputs
-  experiment_name: "gxma_fusion_poc"  # Subdirectory name for this run
+  experiment_name: "gxma_fusion_gated"  # Subdirectory name for this run
   seed: 42
   gpu_id: 1  # GPU ID to use
 
@@ -11,7 +11,7 @@ model:
   hidden_dim: 256
   num_heads: 4
   num_classes: 2
-  fusion_strategy: "concat"
+  fusion_strategy: "gated"
 
 data:
   base_data_dir: "/raid/dannyliu/dataset/GAI_Dataset/genimage/imagenet_ai_0419_sdv4/"

--- a/configs/gxma_fusion_parallel.yaml
+++ b/configs/gxma_fusion_parallel.yaml
@@ -2,7 +2,7 @@
 
 general:
   output_dir: "results/gxma_runs"  # Base directory for all outputs
-  experiment_name: "gxma_fusion_poc"  # Subdirectory name for this run
+  experiment_name: "gxma_fusion_parallel"  # Subdirectory name for this run
   seed: 42
   gpu_id: 1  # GPU ID to use
 
@@ -11,7 +11,7 @@ model:
   hidden_dim: 256
   num_heads: 4
   num_classes: 2
-  fusion_strategy: "concat"
+  fusion_strategy: "parallel"
 
 data:
   base_data_dir: "/raid/dannyliu/dataset/GAI_Dataset/genimage/imagenet_ai_0419_sdv4/"

--- a/src/models/gxma/frequency_extractors.py
+++ b/src/models/gxma/frequency_extractors.py
@@ -71,3 +71,16 @@ class FrequencyFeatureExtractor:
         f_dct = dct_statistics(image)
         f_wavelet = wavelet_statistics(image)
         return torch.cat([f_radial, f_dct, f_wavelet], dim=-0)
+
+
+class FrequencyFeatureExtractorSplit:
+    """Extract frequency features and return them separately."""
+
+    def __init__(self) -> None:
+        pass
+
+    def __call__(self, image: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        f_radial = radial_average_spectrum(image)
+        f_dct = dct_statistics(image)
+        f_wavelet = wavelet_statistics(image)
+        return f_radial, f_dct, f_wavelet

--- a/src/models/gxma/gxma_fusion_detector.py
+++ b/src/models/gxma/gxma_fusion_detector.py
@@ -4,7 +4,10 @@ from typing import List
 from PIL import Image
 import torchvision.transforms as T
 
-from .frequency_extractors import FrequencyFeatureExtractor
+from .frequency_extractors import (
+    FrequencyFeatureExtractor,
+    FrequencyFeatureExtractorSplit,
+)
 from .clip_semantics import CLIPCLSExtractor
 
 
@@ -26,37 +29,124 @@ class CrossAttentionFusion(nn.Module):
         return fused.squeeze(1)
 
 
+class CrossAttentionFusionParallel(nn.Module):
+    """Parallel attention streams for each frequency expert."""
+
+    def __init__(self, freq_dims: List[int], sem_dim: int, hidden_dim: int = 256, num_heads: int = 4) -> None:
+        super().__init__()
+        self.query_proj = nn.Linear(sem_dim, hidden_dim)
+
+        self.key_proj_radial = nn.Linear(freq_dims[0], hidden_dim)
+        self.value_proj_radial = nn.Linear(freq_dims[0], hidden_dim)
+        self.key_proj_dct = nn.Linear(freq_dims[1], hidden_dim)
+        self.value_proj_dct = nn.Linear(freq_dims[1], hidden_dim)
+        self.key_proj_wavelet = nn.Linear(freq_dims[2], hidden_dim)
+        self.value_proj_wavelet = nn.Linear(freq_dims[2], hidden_dim)
+
+        self.attn_radial = nn.MultiheadAttention(embed_dim=hidden_dim, num_heads=num_heads, batch_first=True)
+        self.attn_dct = nn.MultiheadAttention(embed_dim=hidden_dim, num_heads=num_heads, batch_first=True)
+        self.attn_wavelet = nn.MultiheadAttention(embed_dim=hidden_dim, num_heads=num_heads, batch_first=True)
+
+    def forward(self, freq_feats: List[torch.Tensor], sem_feat: torch.Tensor) -> torch.Tensor:
+        f_radial, f_dct, f_wavelet = freq_feats
+        q = self.query_proj(sem_feat).unsqueeze(1)
+
+        k_r = self.key_proj_radial(f_radial).unsqueeze(1)
+        v_r = self.value_proj_radial(f_radial).unsqueeze(1)
+        out_r, _ = self.attn_radial(q, k_r, v_r)
+
+        k_d = self.key_proj_dct(f_dct).unsqueeze(1)
+        v_d = self.value_proj_dct(f_dct).unsqueeze(1)
+        out_d, _ = self.attn_dct(q, k_d, v_d)
+
+        k_w = self.key_proj_wavelet(f_wavelet).unsqueeze(1)
+        v_w = self.value_proj_wavelet(f_wavelet).unsqueeze(1)
+        out_w, _ = self.attn_wavelet(q, k_w, v_w)
+
+        fused = out_r + out_d + out_w
+        return fused.squeeze(1)
+
+
+class GatedCrossAttentionFusion(nn.Module):
+    """Hierarchical gating over parallel attention streams."""
+
+    def __init__(self, freq_dims: List[int], sem_dim: int, hidden_dim: int = 256, num_heads: int = 4) -> None:
+        super().__init__()
+        self.parallel = CrossAttentionFusionParallel(freq_dims, sem_dim, hidden_dim, num_heads)
+        self.gate_net = nn.Sequential(
+            nn.Linear(sem_dim, hidden_dim),
+            nn.ReLU(),
+            nn.Linear(hidden_dim, 3),
+        )
+
+    def forward(self, freq_feats: List[torch.Tensor], sem_feat: torch.Tensor) -> torch.Tensor:
+        f_radial, f_dct, f_wavelet = freq_feats
+        q_feat = self.parallel.query_proj(sem_feat)  # reuse query proj from parallel module
+
+        # compute each attention output using same q
+        out_r = self.parallel.attn_radial(q_feat.unsqueeze(1), self.parallel.key_proj_radial(f_radial).unsqueeze(1), self.parallel.value_proj_radial(f_radial).unsqueeze(1))[0].squeeze(1)
+        out_d = self.parallel.attn_dct(q_feat.unsqueeze(1), self.parallel.key_proj_dct(f_dct).unsqueeze(1), self.parallel.value_proj_dct(f_dct).unsqueeze(1))[0].squeeze(1)
+        out_w = self.parallel.attn_wavelet(q_feat.unsqueeze(1), self.parallel.key_proj_wavelet(f_wavelet).unsqueeze(1), self.parallel.value_proj_wavelet(f_wavelet).unsqueeze(1))[0].squeeze(1)
+
+        gates = torch.softmax(self.gate_net(sem_feat), dim=-1)
+        fused = gates[:, 0:1] * out_r + gates[:, 1:2] * out_d + gates[:, 2:3] * out_w
+        return fused
+
+
 class GXMAFusionDetector(nn.Module):
     """PoC detector combining frequency fingerprints and CLIP semantics."""
 
-    def __init__(self, hidden_dim: int = 256, num_heads: int = 4, num_classes: int = 2) -> None:
+    def __init__(
+        self,
+        hidden_dim: int = 256,
+        num_heads: int = 4,
+        num_classes: int = 2,
+        fusion_strategy: str = "concat",
+    ) -> None:
         super().__init__()
-        self.freq_extractor = FrequencyFeatureExtractor()
+        self.fusion_strategy = fusion_strategy
+
+        if fusion_strategy == "concat":
+            self.freq_extractor = FrequencyFeatureExtractor()
+        else:
+            self.freq_extractor = FrequencyFeatureExtractorSplit()
+
         self.sem_extractor = CLIPCLSExtractor()
-        # frequency vector length: 128 + 64 + 64 = 256
-        freq_dim = 256
-        # Determine semantic feature dimension dynamically from the extractor
+
         sem_dim = self.sem_extractor.hidden_dim
-        self.fusion = CrossAttentionFusion(freq_dim, sem_dim, hidden_dim, num_heads)
+
+        if fusion_strategy == "concat":
+            freq_dim = 256  # 128 + 64 + 64
+            self.fusion = CrossAttentionFusion(freq_dim, sem_dim, hidden_dim, num_heads)
+        elif fusion_strategy == "parallel":
+            self.fusion = CrossAttentionFusionParallel([128, 64, 64], sem_dim, hidden_dim, num_heads)
+        elif fusion_strategy == "gated":
+            self.fusion = GatedCrossAttentionFusion([128, 64, 64], sem_dim, hidden_dim, num_heads)
+        else:
+            raise ValueError(f"Unsupported fusion strategy: {fusion_strategy}")
+
         self.classifier = nn.Sequential(
             nn.Linear(hidden_dim, 128),
             nn.ReLU(),
-            nn.Linear(128, num_classes)
+            nn.Linear(128, num_classes),
         )
 
     def forward(self, images: torch.Tensor) -> torch.Tensor:
         # 'images' is a batch of tensors on the target device (e.g., cuda:1)
         sem_feat = self.sem_extractor(images)
 
-        # freq_extractor expects a single CPU tensor.
-        freq_feats = [self.freq_extractor(img.cpu()) for img in images]
-        freq_feat = torch.stack(freq_feats, dim=0)
-
-        # Move the computed frequency features to the target device.
-        # The target device is determined from the model's parameters.
         target_device = next(self.parameters()).device
-        freq_feat = freq_feat.to(target_device)
 
-        fused = self.fusion(freq_feat, sem_feat)
+        if self.fusion_strategy == "concat":
+            freq_feats = [self.freq_extractor(img.cpu()) for img in images]
+            freq_feat = torch.stack(freq_feats, dim=0).to(target_device)
+            fused = self.fusion(freq_feat, sem_feat)
+        else:
+            freq_feats = [self.freq_extractor(img.cpu()) for img in images]
+            f_radial = torch.stack([f[0] for f in freq_feats], dim=0).to(target_device)
+            f_dct = torch.stack([f[1] for f in freq_feats], dim=0).to(target_device)
+            f_wavelet = torch.stack([f[2] for f in freq_feats], dim=0).to(target_device)
+            fused = self.fusion([f_radial, f_dct, f_wavelet], sem_feat)
+
         logits = self.classifier(fused)
         return logits

--- a/src/training/train_gxma.py
+++ b/src/training/train_gxma.py
@@ -224,6 +224,7 @@ def main(config_path: str, mode: str) -> None:
             hidden_dim=model_cfg.get("hidden_dim", 256),
             num_heads=model_cfg.get("num_heads", 4),
             num_classes=model_cfg.get("num_classes", 2),
+            fusion_strategy=model_cfg.get("fusion_strategy", "concat"),
         ).to(device)
     elif mode == "frequency":
         model = FrequencyOnlyDetector(


### PR DESCRIPTION
## Summary
- extend frequency extractor to output individual features
- implement parallel and gated attention fusion strategies in GXMA detector
- support configurable `fusion_strategy` in training script and configs
- add example configs for parallel and gated strategies
- update documentation for GXMA module and configs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a63b6b0083269c6a59c5cd58a7ef